### PR TITLE
Run flake8 on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ devToolsProject.run(
         }
       },
       black: { data.venv.run('black --check .') },
+      flake8: { data.venv.run('flake8 -v') },
       groovylint: { groovylint.checkSingleFile(path: './Jenkinsfile') },
       molecule: { data.venv.run('molecule --debug test') },
     )

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,3 +1,5 @@
+"""Molecule tests for the default scenario."""
+
 import os
 
 import testinfra.utils.ansible_runner
@@ -9,6 +11,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_paths_file(host):
+    """Test that variables were set correctly."""
     test_paths_file = host.file("/tmp/paths.txt")
     expected_paths = [
         "/usr/bin",  # ansible_pkg_mgr_bin

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,6 +1,9 @@
 ansible
 ansible-lint
 black
+flake8
+flake8-docstrings
+flake8-isort
 molecule
 molecule-docker
 pytest-testinfra

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -67,10 +67,21 @@ enrich==1.2.6
     # via
     #   ansible-lint
     #   molecule
+flake8==3.9.2
+    # via
+    #   -r requirements-dev.in
+    #   flake8-docstrings
+    #   flake8-isort
+flake8-docstrings==1.6.0
+    # via -r requirements-dev.in
+flake8-isort==4.0.0
+    # via -r requirements-dev.in
 idna==3.2
     # via requests
 iniconfig==1.1.1
     # via pytest
+isort==5.9.3
+    # via flake8-isort
 jinja2==3.0.1
     # via
     #   ansible-core
@@ -81,6 +92,8 @@ jinja2-time==0.2.0
     # via cookiecutter
 markupsafe==2.0.1
     # via jinja2
+mccabe==0.6.1
+    # via flake8
 molecule==3.4.0
     # via
     #   -r requirements-dev.in
@@ -107,8 +120,14 @@ poyo==0.5.0
     # via cookiecutter
 py==1.10.0
     # via pytest
+pycodestyle==2.7.0
+    # via flake8
 pycparser==2.20
     # via cffi
+pydocstyle==6.1.1
+    # via flake8-docstrings
+pyflakes==2.3.1
+    # via flake8
 pygments==2.10.0
     # via rich
 pynacl==1.4.0
@@ -157,10 +176,14 @@ six==1.16.0
     #   cookiecutter
     #   pynacl
     #   python-dateutil
+snowballstemmer==2.1.0
+    # via pydocstyle
 subprocess-tee==0.3.2
     # via molecule
 tenacity==8.0.1
     # via ansible-lint
+testfixtures==6.18.1
+    # via flake8-isort
 text-unidecode==1.3
     # via python-slugify
 toml==0.10.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,15 @@
+[flake8]
+exclude = .git,.venv
+filename = *.py
+ignore = W503
+max-line-length = 90
+
+[isort]
+default_section = THIRDPARTY
+include_trailing_comma = 1
+known_first_party = cidre
+line_length = 88
+lines_after_imports = 2
+lines_between_types = 1
+multi_line_output = 3
+order_by_type = False


### PR DESCRIPTION
- Add flake8 to Python requirements
- Remove empty line in imports
- Add docstrings to tests
- Run flake8 on CI
