### PR TITLE
Update Python requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,19 +4,17 @@
 #
 #    pip-compile --output-file=requirements-dev.txt requirements-dev.in
 #
-ansible==4.4.0
+ansible==4.6.0
     # via -r requirements-dev.in
 ansible-compat==0.5.0
-    # via molecule-docker
-ansible-core==2.11.4
-    # via ansible
-ansible-lint==5.1.2
     # via
-    #   -r requirements-dev.in
     #   molecule
-appdirs==1.4.4
-    # via black
-arrow==1.1.1
+    #   molecule-docker
+ansible-core==2.11.5
+    # via ansible
+ansible-lint==5.2.0
+    # via -r requirements-dev.in
+arrow==1.2.0
     # via jinja2-time
 attrs==21.2.0
     # via pytest
@@ -24,7 +22,7 @@ bcrypt==3.2.0
     # via paramiko
 binaryornot==0.4.4
     # via cookiecutter
-black==21.7b0
+black==21.9b0
     # via -r requirements-dev.in
 bracex==2.1.1
     # via wcmatch
@@ -39,7 +37,7 @@ cffi==1.14.6
     #   pynacl
 chardet==4.0.0
     # via binaryornot
-charset-normalizer==2.0.4
+charset-normalizer==2.0.6
     # via requests
 click==8.0.1
     # via
@@ -55,13 +53,13 @@ commonmark==0.9.1
     # via rich
 cookiecutter==1.7.3
     # via molecule
-cryptography==3.4.8
+cryptography==35.0.0
     # via
     #   ansible-core
     #   paramiko
 distro==1.6.0
     # via selinux
-docker==5.0.0
+docker==5.0.2
     # via molecule-docker
 enrich==1.2.6
     # via
@@ -82,7 +80,7 @@ iniconfig==1.1.1
     # via pytest
 isort==5.9.3
     # via flake8-isort
-jinja2==3.0.1
+jinja2==3.0.2
     # via
     #   ansible-core
     #   cookiecutter
@@ -94,7 +92,7 @@ markupsafe==2.0.1
     # via jinja2
 mccabe==0.6.1
     # via flake8
-molecule==3.4.0
+molecule==3.5.2
     # via
     #   -r requirements-dev.in
     #   molecule-docker
@@ -112,7 +110,9 @@ paramiko==2.7.2
     # via molecule
 pathspec==0.9.0
     # via black
-pluggy==0.13.1
+platformdirs==2.4.0
+    # via black
+pluggy==1.0.0
     # via
     #   molecule
     #   pytest
@@ -134,7 +134,7 @@ pynacl==1.4.0
     # via paramiko
 pyparsing==2.4.7
     # via packaging
-pytest==6.2.4
+pytest==6.2.5
     # via pytest-testinfra
 pytest-testinfra==6.4.0
     # via -r requirements-dev.in
@@ -148,7 +148,7 @@ pyyaml==5.4.1
     #   ansible-core
     #   ansible-lint
     #   molecule
-regex==2021.8.21
+regex==2021.9.30
     # via black
 requests==2.26.0
     # via
@@ -157,12 +157,12 @@ requests==2.26.0
     #   molecule-docker
 resolvelib==0.5.4
     # via ansible-core
-rich==10.7.0
+rich==10.12.0
     # via
     #   ansible-lint
     #   enrich
     #   molecule
-ruamel.yaml==0.17.14
+ruamel.yaml==0.17.16
     # via ansible-lint
 ruamel.yaml.clib==0.2.6
     # via ruamel.yaml
@@ -178,11 +178,11 @@ six==1.16.0
     #   python-dateutil
 snowballstemmer==2.1.0
     # via pydocstyle
-subprocess-tee==0.3.2
+subprocess-tee==0.3.5
     # via molecule
 tenacity==8.0.1
     # via ansible-lint
-testfixtures==6.18.1
+testfixtures==6.18.3
     # via flake8-isort
 text-unidecode==1.3
     # via python-slugify
@@ -190,7 +190,9 @@ toml==0.10.2
     # via pytest
 tomli==1.2.1
     # via black
-urllib3==1.26.6
+typing-extensions==3.10.0.2
+    # via black
+urllib3==1.26.7
     # via requests
 wcmatch==8.2
     # via ansible-lint


### PR DESCRIPTION
As we do not (yet) have dependabot fully up-and-running in this
repository, we need to manually update the Python requirements in
order to fix flakey molecule tests.
