### PR TITLE
Fix Windows versions in metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,7 +19,6 @@ galaxy_info:
         - all
     - name: Windows
       versions:
-        - 8.1
-        - 10
+        - all
 
 dependencies: []


### PR DESCRIPTION
This fixes a warning from Ansible Galaxy about unknown Windows versions when importing the role.