### PR TITLE
Explicitly add ansible-core as a dependency

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,3 +1,4 @@
+ansible-core
 ansible-lint
 black
 flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,9 @@ ansible-compat==2.1.0
     #   ansible-lint
     #   molecule
 ansible-core==2.13.1
-    # via ansible-lint
+    # via
+    #   -r requirements-dev.in
+    #   ansible-lint
 ansible-lint==6.3.0
     # via -r requirements-dev.in
 arrow==1.2.0


### PR DESCRIPTION
We get ansible-core via ansible-lint, but we should depend on it
directly as we are also running ansible-galaxy in the Jenkinsfile.
Should have been done in aae41ff.
