### PR TITLE
Remove unnecessary failFast argument to parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ devToolsProject.run(
   },
   test: { data ->
     data.venv.inside {
-      parallel(failFast: false,
+      parallel(
         'ansible-lint': {
           sh(
             label: 'ansible-lint',


### PR DESCRIPTION
`false` is already the default value for this argument.