### PR TITLE
Update ableton-utils to 0.24.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-library(identifier: 'ableton-utils@0.23', changelog: false)
+library(identifier: 'ableton-utils@0.24', changelog: false)
 library(identifier: 'groovylint@0.13', changelog: false)
 library(identifier: 'python-utils@0.13', changelog: false)
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   roles:
-    - ansible-role-pkg-mgr-path
+    - ableton.pkg_mgr_path
   tasks:
     - name: Write variables to file
       copy:


### PR DESCRIPTION
This update contains some improvements with how Ansible roles are tested with Molecule that will allow us to remove some of our hacks regarding role naming in the Molecule configuration files.