### PR TITLE
Remove unneccessary pin for requests

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -2,5 +2,3 @@ ansible-core
 ansible-lint
 molecule
 molecule-plugins[docker]
-# TODO: Remove this once Molecule has been fixed to work with requests >2.31
-requests==2.32.5


### PR DESCRIPTION
As we've allowed Dependabot to update requests beyond v2.31, clearly
Molecule has been fixed to work with it and so this pin is no longer
required.
