### PR TITLE
Add Molecule tests for Ubuntu 24.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .ansible
+__pycache__

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,8 +4,10 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: instance
+  - name: ansible-role-pkg-mgr-path-focal
     image: ubuntu:20.04
+  - name: ansible-role-pkg-mgr-path-noble
+    image: ubuntu:24.04
 provisioner:
   name: ansible
   log: true


### PR DESCRIPTION
- **Ignore __pycache__ directory**
- **Add Molecule tests for Ubuntu 24.04**
